### PR TITLE
fix(profile): improve text input spacing and bio line breaks

### DIFF
--- a/app/(authenticated)/profile/[userId]/page.js
+++ b/app/(authenticated)/profile/[userId]/page.js
@@ -168,7 +168,7 @@ export default function ProfilePage() {
 
               <div className="mt-4 space-y-2">
                 {profile.bio && (
-                  <p className="text-gray-600">{profile.bio}</p>
+                  <p className="text-gray-600 whitespace-pre-wrap">{profile.bio}</p>
                 )}
                 <div className="flex flex-wrap gap-4 text-sm text-gray-500">
                   {profile.location && (

--- a/app/(authenticated)/profile/edit/page.jsx
+++ b/app/(authenticated)/profile/edit/page.jsx
@@ -240,7 +240,7 @@ export default function EditProfilePage() {
               name="username"
               value={formData.username}
               onChange={handleUsernameChange}
-              className="block w-full rounded-md border-gray-300 pr-10 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+              className="block w-full rounded-md border-gray-300 px-4 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
               required
             />
             <div className="absolute inset-y-0 right-0 flex items-center pr-3">
@@ -270,7 +270,7 @@ export default function EditProfilePage() {
             name="name"
             value={formData.name}
             onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+            className="mt-1 block w-full rounded-md border-gray-300 px-4 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
           />
         </div>
 
@@ -284,7 +284,7 @@ export default function EditProfilePage() {
             rows={4}
             value={formData.bio}
             onChange={(e) => setFormData(prev => ({ ...prev, bio: e.target.value }))}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+            className="mt-1 block w-full rounded-md border-gray-300 px-4 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
           />
         </div>
 


### PR DESCRIPTION
- Add proper padding (px-4 py-2) to all text inputs in profile edit form
- Preserve line breaks in bio text using whitespace-pre-wrap
- Match text input styling with feed page for consistency

Fixes #23