### PR TITLE
fix: resolve Vercel deployment path alias issues

### DIFF
--- a/app/api/follow/route.js
+++ b/app/api/follow/route.js
@@ -1,5 +1,5 @@
 // app/api/follow/route.js
-import { createClient } from '@/utils/supabase/server';
+import { createClient } from '../../../utils/supabase/server';
 import { NextResponse } from 'next/server';
 
 export async function POST(request) {

--- a/app/api/posts/route.js
+++ b/app/api/posts/route.js
@@ -1,5 +1,5 @@
 // app/api/posts/route.js
-import { createClient } from '@/utils/supabase/server';
+import { createClient } from '../../../utils/supabase/server';
 import { NextResponse } from 'next/server';
 
 export async function POST(request) {


### PR DESCRIPTION
- Replace @/ path aliases with relative paths in API routes
- Update imports in:
  - app/api/follow/route.js
  - app/api/posts/route.js

This fixes the module resolution errors during Vercel deployment while maintaining consistent import patterns across the codebase.

Issue: Module not found: Can't resolve '@/utils/supabase/server'